### PR TITLE
Remove adapter_defaults.upload_features from TextEmbeddings

### DIFF
--- a/adapters/text_embeddings/text_embeddings.py
+++ b/adapters/text_embeddings/text_embeddings.py
@@ -34,10 +34,8 @@ class TextEmbeddings(dl.BaseModelAdapter):
 
         for item in batch:
             if isinstance(item, str):
-                self.adapter_defaults.upload_features = True
                 text = item
             else:
-                self.adapter_defaults.upload_features = False
                 try:
                     prompt_item = dl.PromptItem.from_item(item)
                     is_hyde = item.metadata.get('prompt', dict()).get('is_hyde', False)


### PR DESCRIPTION
## Summary
- Removed `self.adapter_defaults.upload_features = True` and `self.adapter_defaults.upload_features = False` from the `embed` method in `TextEmbeddings`
- This flag is no longer needed in the text embeddings adapter

## Test plan
- [ ] Verify text embeddings adapter works correctly with string inputs
- [ ] Verify text embeddings adapter works correctly with item inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)